### PR TITLE
Upgrade to uuid version 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lodash.mapvalues": "^4.6.0"
   },
   "peerDependencies": {
-    "uuid": "^3.2.x",
+    "uuid": "^8.0.0",
     "graphql-subscriptions": "^0.5.x || ^1.0.0"
   },
   "scripts": {

--- a/src/asyncIterator.ts
+++ b/src/asyncIterator.ts
@@ -2,7 +2,7 @@ import { Observable, Event, AsyncIteratorConfig } from './defs';
 import { pubsub, eventEmitter } from './pubsub';
 
 // Because `module.exports` gets weirdly transformed by typescript
-const uuid = require('uuid/v4');
+const { v4: uuid } = require('uuid');
 let observers = {};
 
 /**


### PR DESCRIPTION
Older versions of `uuid` would show this warning: 
```
DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated for more information.
```
 This was because this package used a `require` pattern that was now deprecated.

Version 8 was released and removed the ability to `require` in the format this package was using. `const uuid = require('uuid/v4');` must become `const { v4: uuid } = require('uuid');`. See: https://github.com/uuidjs/uuid/blob/master/CHANGELOG.md#-breaking-changes

This PR updates the peer dependency to use version 8, the latest `uuid` package, and updates to the new `require` pattern.